### PR TITLE
Unexpected keyword - probably due to a quick copy

### DIFF
--- a/stratum/server.py
+++ b/stratum/server.py
@@ -97,8 +97,7 @@ def setup_finalize(event, application):
                                                            debug=settings.DEBUG,
                                                            signing_key=signing_key,
                                                            signing_id=settings.SIGNING_ID,
-                                                           event_handler=ServiceEventHandler,
-                                                           tcp_proxy_protocol_enable=settings.TCP_PROXY_PROTOCOL)
+                                                           event_handler=ServiceEventHandler)
         listenWS(ws)
     
     if settings.LISTEN_WSS_TRANSPORT and sslContext:  


### PR DESCRIPTION
tcp_proxy_protocol_enable was being passed from settings to websocket_transport in setup.py, that was resulting in a crash because the keyword wasn't expected in websocket_transport.py
