### PR TITLE
Increase LineOnlyReader.MAX_LENGTH to prevent large gentxs from making mining proxy disconnect

### DIFF
--- a/stratum/protocol.py
+++ b/stratum/protocol.py
@@ -36,6 +36,7 @@ class RequestCounter(object):
                 
 class Protocol(LineOnlyReceiver):
     delimiter = '\n'
+    MAX_LENGTH = 1638400
     
     def _get_id(self):
         self.request_id += 1


### PR DESCRIPTION
Fixes problem with connecting to P2Pool:

```
2013-05-26 17:01:44,371 INFO stats stats.print_stats # 1 peers connected, state changed 1 times
2013-05-26 17:01:44,372 INFO proxy mining_proxy.on_connect # Connected to Stratum pool at 127.0.0.1:9332
2013-05-26 17:01:44,372 INFO proxy mining_proxy.on_connect # Subscribing for mining jobs
2013-05-26 17:01:44,396 INFO proxy client_service.handle_event # Setting new difficulty: 0.999984741211
2013-05-26 17:01:44,396 INFO proxy mining_proxy.on_disconnect # Disconnected from Stratum pool at 127.0.0.1:9332
2013-05-26 17:01:44,396 INFO stats stats.print_stats # 0 peers connected, state changed 1 times
```
