### PR TITLE
Update distribute_setup.py

### DIFF
--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -47,7 +47,7 @@ except ImportError:
         return os.spawnl(os.P_WAIT, sys.executable, *args) == 0
 
 DEFAULT_VERSION = "0.6.28"
-DEFAULT_URL = "http://pypi.python.org/packages/source/d/distribute/"
+DEFAULT_URL = "https://pypi.python.org/packages/source/d/distribute/"
 SETUPTOOLS_FAKED_VERSION = "0.6c11"
 
 SETUPTOOLS_PKG_INFO = """\


### PR DESCRIPTION
PIP no longer allows for the installation of packages that don't use https in the DEFAULT_URL. I was having a real hard time installing this with PIP in the beginning. This small change fixes it.