### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from distribute_setup import use_setuptools
-use_setuptools()
 
 #python setup.py sdist upload
 


### PR DESCRIPTION
Distribute has been deprecated, and pypi no longer allows https connections.  Removing these 2 lines fixes both issues.